### PR TITLE
Remove sed call to manipulate Duo parameter, set via env var instead.

### DIFF
--- a/bitwarden_rs_heroku.sh
+++ b/bitwarden_rs_heroku.sh
@@ -66,8 +66,8 @@ function build_image {
 
     if [ "${ENABLE_DUO}" -eq "1" ]
     then
-        echo "In order to maintain Duo with presistence for those who run replicas and have Duo enable by default, we modify the default config (src/config.rs) to enable Duo by default."
-        sed_files 's/_enable_duo:            bool,   true,   def,     false;/_enable_duo:            bool,   true,   def,     true;/g' ./${BITWARDEN_RS_FOLDER}/src/config.rs
+        # Thank you bryanjhv!
+        heroku config:set _ENABLE_DUO=true -a "${APP_NAME}"
     fi
 
     echo "Logging into Heroku Container Registry to push the image (this will add an entry in your Docker config)"


### PR DESCRIPTION
This removes the sed manipulation in the config file and sets the Duo variable via env var, making it much more portable and less hack-y.