### PR TITLE
Remove unnecessary email parameter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,6 @@ env:
   CREATE_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
   DUO_ENABLE: 1
   GIT_HASH: master
-  HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
   HEROKU_VERIFIED: 1
   OFFSITE_HEROKU_DB: ${{ secrets.OFFSITE_HEROKU_DB }}

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -9,7 +9,6 @@ env:
   CREATE_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
   DUO_ENABLE: 1
   GIT_HASH: master
-  HEROKU_EMAIL: ${{ secrets.HEROKU_EMAIL }}
   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Usage is simply, fast, and user friendly!
 1. Create a fork of this project
 2. Edit the `.github/workflows/deploy.yml` to enable/disable Duo and/or modify the checkout hash of bitwarden_rs upstream.
 3. Go to your forked repo Settings > Secrets and add secrets for:
-  * HEROKU_EMAIL (the email you used to sign up for Heroku)
   * HEROKU_API_KEY (yoru Heroku API key - can be found in **[Account Setings](https://dashboard.heroku.com/account)** -> APi Keys)
   * HEROKU_APP_NAME (the name of the Heroku application, this must be unqiue across Heroku and will fail if it is not) [Value alphanumerical]
   * **HEROKU_VERIFIED (required regardless, if you have added a credit card on, your account will be verified to use built in addons, if not please see "NON VERIFIED ACCOUNTS" section)** [Value 0/1]

--- a/bitwarden_rs_heroku.sh
+++ b/bitwarden_rs_heroku.sh
@@ -82,18 +82,6 @@ function build_image {
     heroku container:release web -a "${APP_NAME}"
 }
 
-function login_heroku {
-echo "Modify netrc file to include Heroku details"
-cat >~/.netrc <<EOF
-machine api.heroku.com
-    login ${HEROKU_EMAIL}
-    password ${HEROKU_API_KEY}
-machine git.heroku.com
-    login ${HEROKU_EMAIL}
-    password ${HEROKU_API_KEY}
-EOF
-}
-
 function help {
     printf "Welcome to help!\Use option -a for app name,\n-d <0/1> to enable duo,\n -g to set a git hash to clone bitwarden_rs from,\n and -t to specify if deployment or update!"
 }
@@ -118,7 +106,6 @@ echo "Heroku Verified: $HEROKU_VERIFIED";
 if [[ ${STRATEGY_TYPE} = "deploy" ]]
 then
     echo "Run Heroku bootstrapping for app and Dyno creations."
-    login_heroku
     heroku_bootstrap "${CREATE_APP_NAME}"
     APP_NAME=${CREATE_APP_NAME}
     build_image
@@ -126,7 +113,6 @@ then
 elif [[ ${STRATEGY_TYPE} = "update" ]]
 then
     APP_NAME=${CREATE_APP_NAME}
-    login_heroku
     build_image
 else
     echo "Unexpected workflow, failing build"


### PR DESCRIPTION
After checking out [Heroku documentation](https://devcenter.heroku.com/articles/authentication#api-token-storage), and some old [GitHub action](https://github.com/actions/heroku#secrets), I discovered that it's not necessary to set the email address for Heroku CLI as long as you set the `HEROKU_API_KEY` environment variable.

The first link also tells that `.netrc` is useful when using Heroku's HTTP Git service, which your script doesn't use (because it just pushes to container registry), so it's safe to also remove that step from the build (maybe while avoiding side effects).

I have tested this on GitHub Actions environment, and it works, as you can see:
(the commit hashes match with the one from this pull request)

https://github.com/bryanjhv/bitwarden_rs_heroku/actions/runs/587779699